### PR TITLE
Add cluster directories deletion for clusters not in the cluster list

### DIFF
--- a/test/clusterGitOpsClient.test.ts
+++ b/test/clusterGitOpsClient.test.ts
@@ -36,7 +36,30 @@ describe('ClusterGitOpsClient', () => {
   });
 
   describe('apply', () => {
-    it.skip('prunes cluster directories not present in the cluster list', async () => {});
+    it('prunes cluster directories for clusters that are not present in the cluster list', async () => {
+      const tmpDir = await generateClusterGitopsRepo();
+      const clusters: Cluster[] = [
+        {
+          kind: 'Cluster',
+          metadata: {
+            name: 'cluster1',
+          },
+          spec: {},
+        },
+      ];
+      const clustersDir = path.join(tmpDir, 'clusters');
+      const cluster1Dir = path.join(clustersDir, 'cluster1');
+      const cluster2Dir = path.join(clustersDir, 'cluster2');
+      await fs.mkdir(cluster1Dir, {recursive: true});
+      await fs.mkdir(cluster2Dir, {recursive: true});
+
+      const client = new ClusterGitOpsClient(tmpDir);
+      await client.apply(clusters, []);
+
+      expect(existsSync(cluster1Dir)).to.equal(true);
+      expect(existsSync(path.join(clustersDir, 'base'))).to.equal(true);
+      expect(existsSync(cluster2Dir)).to.equal(false);
+    });
 
     it('removes extra files present in the cluster directory', async () => {
       const tmpDir = await generateClusterGitopsRepo();

--- a/test/util.ts
+++ b/test/util.ts
@@ -5,6 +5,12 @@ import simpleGit from 'simple-git';
 
 export async function generateClusterGitopsRepo(): Promise<string> {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), '/'));
+
+  const clustersDir = path.join(tmpDir, 'clusters');
+  await fs.mkdir(clustersDir, {recursive: true});
+  const clustersBaseDir = path.join(clustersDir, 'base');
+  await fs.mkdir(clustersBaseDir, {recursive: true});
+
   const git = simpleGit(tmpDir);
   await git.init();
   await git.addRemote(


### PR DESCRIPTION
- Adds deletion of obsolete cluster folders
- Updates test utilities with adding basic directories (clusters, base) to the generated test Cluster Gitops Repo
-
Related task: [13469](https://dev.azure.com/CSECodeHub/Multicloud%20Control%20Plane/_sprints/taskboard/Multicloud%20Control%20Plane%20Team/Multicloud%20Control%20Plane/Sprint%2014?workitem=13469)