### PR TITLE
Clear no longer present App Deployments

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -16,7 +16,7 @@ import * as path from 'path';
 import Mustache = require('mustache');
 import {promises as fs} from 'fs';
 import {existsSync} from 'fs';
-import { ClusterGitOpsClient } from './clusterGitOpsClient';
+import {ClusterGitOpsClient} from './clusterGitOpsClient';
 
 export class ApplicationTemplateNotFoundError extends Error {
   constructor(application: string, template: string) {

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -209,7 +209,9 @@ describe('render', () => {
 
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), '/'));
 
-    await expect(renderAll(deployments, templates, tmpDir)).to.be.rejectedWith(ApplicationDeploymentDuplicateError);
+    await expect(renderAll(deployments, templates, tmpDir)).to.be.rejectedWith(
+      ApplicationDeploymentDuplicateError
+    );
   });
 
   describe('values', () => {


### PR DESCRIPTION
- resets the gitops repo applications folder to empty before running renderAll to clear outdated applications
- checks for non-unique application deployment names since the gitops file structure depends on the app deployment names as the folder name
- adds test for non unique app deployment names
- updates `clears old files from the output directory` test to 'clears old applications from the output directory'

fixes [AB#13509](https://dev.azure.com/CSECodeHub/Multicloud%20Control%20Plane/_workitems/edit/13509)